### PR TITLE
Fix Dir.readSync to declare a null return value

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -105,7 +105,7 @@ declare module "fs" {
          * If there are no more directory entries to read, null will be returned.
          * Directory entries returned by this function are in no particular order as provided by the operating system's underlying directory mechanisms.
          */
-        readSync(): Dirent;
+        readSync(): Dirent | null;
     }
 
     export interface FSWatcher extends events.EventEmitter {


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v14.x/docs/api/fs.html#fs_dir_readsync
